### PR TITLE
Add necessary feature flags to compile on nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 
 language: rust
+rust: nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 //!
 #![feature(test)]
 #![feature(core)]
+#![feature(raw)]
+#![feature(nonzero)]
 
 extern crate mmap;
 extern crate iobuf;


### PR DESCRIPTION
I was trying to play with Reactor on nightly and received the following errors:

``` rust
src/block_allocator.rs:92:20: 92:34 error: use of unstable library feature 'raw'
src/block_allocator.rs:92         let repr : raw::Slice<u8> = buf.repr();
                                             ^~~~~~~~~~~~~~
src/block_allocator.rs:92:20: 92:34 help: add #![feature(raw)] to the crate attributes to enable
src/block_allocator.rs:92:41: 92:47 error: use of unstable library feature 'raw'
src/block_allocator.rs:92         let repr : raw::Slice<u8> = buf.repr();
                                                                  ^~~~~~
src/block_allocator.rs:92:41: 92:47 help: add #![feature(raw)] to the crate attributes to enable
src/block_allocator.rs:93:28: 93:32 error: use of unstable library feature 'raw'
src/block_allocator.rs:93         self.free_raw(repr.data as *mut u8);
                                                     ^~~~
src/block_allocator.rs:93:28: 93:32 help: add #![feature(raw)] to the crate attributes to enable
src/buf.rs:4:5: 4:27 error: use of unstable library feature 'nonzero': needs an RFC to flesh out the design
src/buf.rs:4 use core::nonzero::NonZero;
                 ^~~~~~~~~~~~~~~~~~~~~~
src/buf.rs:4:5: 4:27 help: add #![feature(nonzero)] to the crate attributes to enable
src/buf.rs:12:31: 12:47 error: use of unstable library feature 'nonzero': needs an RFC to flesh out the design
src/buf.rs:12     fn deallocate(&self, ptr: NonZero<*mut u8>, _: usize, _: usize) {
                                            ^~~~~~~~~~~~~~~~
src/buf.rs:12:31: 12:47 help: add #![feature(nonzero)] to the crate attributes to enable
error: aborting due to 5 previous errors
Could not compile `block_allocator`.
```
